### PR TITLE
Add note about the required ROOT version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,14 @@ In the `course/exercises/core` you will find the exercises that you should attem
 after going through the notebooks with the course material. The course is written in 
 python and it doesn't require much of the C++ knowledge.
 
-The in-person course based on the material in this repository was recorded during the summer of 2024. The recording is available [here](https://videos.cern.ch/record/2300516). We encourage you to watch the video and follow along with the notebooks and exercises. 
+The in-person course based on the material in this repository was recorded during the summer of 2025. The recording is available [here](https://videos.cern.ch/record/2300516). We encourage you to watch the video and follow along with the notebooks and exercises. 
 
 If you want to know a bit more and attempt a few more exercises, including those written 
 in C++, you can first go through some [extra slides](https://docs.google.com/presentation/d/1iNSwzuhmhJAmU3c1_0SfYgqbr-N7BKILpcAJjojXkSg/edit?usp=sharing) and then go to the `course/exercises/extra` 
 section.
 
 Enjoy! And in case of any issues, don't hesitate to ask on our [forum](https://root-forum.cern.ch). 
+
+## Note on ROOT version to be used
+
+The newest part of this course uses Unified Histogram Interface (UHI) features that are only available with ROOT version 6.36 or higher. The two cells that use UHI are marked in the notebook: `course/notebooks/core/01-histograms-and-graphs.ipynb`, otherwise an older version of ROOT can be used as well, for example 6.34. Please note that if you are using SWAN with LCG 107, you will use ROOT 6.34 and therefore the two cells which use UHI will not work.

--- a/course/notebooks/core/01-histograms-and-graphs.ipynb
+++ b/course/notebooks/core/01-histograms-and-graphs.ipynb
@@ -155,6 +155,8 @@
     }
    },
    "source": [
+    "Please note that for the following two cells ROOT version 6.36 (or higher) is required. If you experience failures, check which ROOT version you are using. If your ROOT version is lower than 6.36, you can move on to the ROOT functions section.\n",
+    "\n",
     "ROOT histograms implement the [Unified Histogram Interface (UHI)](https://uhi.readthedocs.io/en/latest/), you can find implementation details and examples on the [ROOT documentation](https://root.cern.ch/doc/master/group__uhi__docs.html).\n",
     "\n",
     "To quickly try it out, let's set some bins of a `TH1D` and plot it with [`mplhep`](https://mplhep.readthedocs.io/en/latest/):"


### PR DESCRIPTION
Adding a note about the ROOT version required for UHI to avoid confusion. The note in the READme will be removed once newer version of ROOT is available in a stable LCG release. 
